### PR TITLE
Column dropdown fix

### DIFF
--- a/lib/garden_widget_updater.rb
+++ b/lib/garden_widget_updater.rb
@@ -22,6 +22,8 @@ class GardenWidgetUpdater
     update_column_widget_garden_widgets_setting
   end
 
+  private  
+  
   def update(garden_widget, component=nil)
     component ||= garden_widget.component_microformat
     garden_widget.url = get_url(component)
@@ -41,8 +43,6 @@ class GardenWidgetUpdater
     garden_widget.save
     garden_widget.update_widgets_settings!
   end
-
-  private  
 
   def update_row_widget_garden_widgets_setting
     Website.all.each do |website|

--- a/lib/garden_widget_updater.rb
+++ b/lib/garden_widget_updater.rb
@@ -17,6 +17,9 @@ class GardenWidgetUpdater
     removed_garden_widgets.each do |removed_garden_widget|
       removed_garden_widget.destroy
     end
+
+    update_row_widget_garden_widgets_setting
+    update_column_widget_garden_widgets_setting
   end
 
   def update(garden_widget, component=nil)
@@ -37,9 +40,9 @@ class GardenWidgetUpdater
     garden_widget.widget_modified = get_modified(component)
     garden_widget.save
     garden_widget.update_widgets_settings!
-    update_row_widget_garden_widgets_setting
-    update_column_widget_garden_widgets_setting
   end
+
+  private  
 
   def update_row_widget_garden_widgets_setting
     Website.all.each do |website|
@@ -54,8 +57,6 @@ class GardenWidgetUpdater
       setting.update_attributes!(value: ColumnWidgetGardenWidgetsSetting.new.value)
     end
   end
-
-  private
 
   def components_microformats
     GardenWidget.components_microformats


### PR DESCRIPTION
move `update_row_widget_garden_widgets_setting` and `update_column_widget_garden_widgets_setting` to `update_all`
those methods only need to be called once, not per widget.

this will also allow page builders to use update widgets to fix the nil dropdown in the column widget in the case when widget timestamps already match.

https://www.pivotaltracker.com/n/projects/877197/stories/85928238