### PR TITLE
Revision

### DIFF
--- a/config/initializers/1git_revision.rb
+++ b/config/initializers/1git_revision.rb
@@ -1,3 +1,0 @@
-module G5CMS
-  REVISION = `git log --pretty=format:'%h' -n 1`
-end

--- a/config/initializers/g5_header.rb
+++ b/config/initializers/g5_header.rb
@@ -1,3 +1,3 @@
 G5Header.setup do |config|
-  config.app_name = "Content Management System (CMS) v#{G5CMS::REVISION}"
+  config.app_name = "Content Management System (CMS)"
 end

--- a/config/initializers/g5_header.rb
+++ b/config/initializers/g5_header.rb
@@ -1,3 +1,3 @@
 G5Header.setup do |config|
-  config.app_name = "Content Management System (CMS)"
+  config.app_name = "Content Management System (CMS) "
 end


### PR DESCRIPTION
Removes initializer to set revision as a constant. Removes reference to constant in the header bar. Stupid heroku deletes the .git directory before slug compilation to save space.