### PR TITLE
Areapage

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -18,11 +18,14 @@ class Location < ActiveRecord::Base
 
   default_scope { order("corporate DESC") }
 
-  scope :corporate, -> { where(corporate: true).first }
   scope :live, -> { where(status: "Live") }
   scope :live_websites, -> { live.map(&:website) }
 
   before_validation :set_city_slug_from_city
+
+  def self.corporate
+    where(status: "Live").first
+  end
 
   def website_id
     website.try(:id)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -24,7 +24,7 @@ class Location < ActiveRecord::Base
   before_validation :set_city_slug_from_city
 
   def self.corporate
-    where(status: "Live").first
+    where(corporate: true).first
   end
 
   def website_id

--- a/lib/area_page_renderer.rb
+++ b/lib/area_page_renderer.rb
@@ -1,5 +1,6 @@
 class AreaPageRenderer
   def initialize(locations, area)
+    Resque.logger.debug("Intitializing AreaPageRenderer with(locations,area): #{locations}, #{area}")
     @locations = locations
     @area = area
   end

--- a/lib/client_deployer.rb
+++ b/lib/client_deployer.rb
@@ -29,6 +29,7 @@ module ClientDeployer
   end
 
   def self.area_pages(compile_path)
+    LOGGERS.each {|logger| logger.debug("in area_pages with compile_path: #{compile_path}")}
     StaticWebsite::Compiler::AreaPages.new(compile_path, Location.live_websites)
   end
 

--- a/lib/client_deployer.rb
+++ b/lib/client_deployer.rb
@@ -9,7 +9,7 @@ module ClientDeployer
   def self.compile_and_deploy(client, user_email)
     LOGGERS.each {|logger| logger.debug("Sending compile to base_compiler")}
     base_compiler(client).compile
-    LOGGERS.each {|logger| logger.info("Sending compile to area_pages")}
+    LOGGERS.each {|logger| logger.info("Sending compile to area_pages(client.website.compile_path): #{client.website.compile_path}" )}
     area_pages(client.website.compile_path).compile
     LOGGERS.each {|logger| logger.info("Calling compile_location_websites")}
     compile_location_websites

--- a/lib/client_deployer.rb
+++ b/lib/client_deployer.rb
@@ -10,6 +10,7 @@ module ClientDeployer
     LOGGERS.each {|logger| logger.debug("Sending compile to base_compiler")}
     base_compiler(client).compile
     LOGGERS.each {|logger| logger.info("Sending compile to area_pages(client.website.compile_path): #{client.website.compile_path}" )}
+    LOGGERS.each {|logger| logger.debug("failing on calling this with compile method: #{area_pages(client.website.compile_path)}")
     area_pages(client.website.compile_path).compile
     LOGGERS.each {|logger| logger.info("Calling compile_location_websites")}
     compile_location_websites

--- a/lib/client_deployer.rb
+++ b/lib/client_deployer.rb
@@ -7,16 +7,11 @@ LOGGERS = [Rails.logger, Resque.logger]
 
 module ClientDeployer
   def self.compile_and_deploy(client, user_email)
-    LOGGERS.each {|logger| logger.debug("Sending compile to base_compiler")}
+    LOGGERS.each {|logger| logger.debug("ClientDeployer: Sending compile to base_compiler")}
     base_compiler(client).compile
-    LOGGERS.each {|logger| logger.info("Sending compile to area_pages(client.website.compile_path): #{client.website.compile_path}" )}
-    LOGGERS.each {|logger| logger.debug("failing on calling this with compile method: #{area_pages(client.website.compile_path)}")
     area_pages(client.website.compile_path).compile
-    LOGGERS.each {|logger| logger.info("Calling compile_location_websites")}
     compile_location_websites
-    LOGGERS.each {|logger| logger.info("Sending client to deployer and sending deploy")}
     deployer(client, user_email).deploy
-    LOGGERS.each {|logger| logger.debug("Calling cleanup with path: #{client.website.compile_path}")}
     cleanup(client.website.compile_path)
   end
 

--- a/lib/static_website/compiler/area_page.rb
+++ b/lib/static_website/compiler/area_page.rb
@@ -30,6 +30,10 @@ module StaticWebsite
 
     private
 
+      def corporate_location
+        Location.corporate || Location.first
+      end
+
       def compile_path
         File.join(@base_path.to_s, @slug, "index.html")
       end
@@ -41,12 +45,12 @@ module StaticWebsite
       def view_options
         LOGGERS.each {|logger| logger.debug("creating view_options hash")}
         LOGGERS.each {|logger| logger.debug("going to call LocationCollector.new with #{@params} and then .collect")}
-        LOGGERS.each {|logger| logger.debug("setting web_template to: #{Location.corporate.website.website_template.to_s}")}
+        LOGGERS.each {|logger| logger.debug("setting web_template to: #{corporate_location.website.website_template.to_s}")}
         LOGGERS.each {|logger| logger.debug("setting area to: #{area.to_s}")}
         options = { layout: "web_template",
           locals: {
             locations: LocationCollector.new(@params).collect,
-            web_template: Location.corporate.website.website_template,
+            web_template: corporate_location.website.website_template,
             area: area,
             params: @params,
             mode: "deployed"

--- a/lib/static_website/compiler/area_pages.rb
+++ b/lib/static_website/compiler/area_pages.rb
@@ -2,6 +2,7 @@ module StaticWebsite
   module Compiler
     class AreaPages
       def initialize(base_path, websites)
+        LOGGERS.each {|logger| logger.debug("initializing Compiler::AreaPages with (base_path, websites): #{base_path} #{websites}")}
         @base_path = base_path
         @websites = websites
       end


### PR DESCRIPTION
fixes issues of scoping, no corp designation.

changes the scope to a class method so we always know what we're getting. This was causing confusion when the scope would return a single record in the case of one existing, and a relation in the case when there were no hits.

This allows for a deploy to happen in the case of no location with corp designation by substituting for an arbitrary location when certain attributes must be found.

https://www.pivotaltracker.com/story/show/89029990