### PR TITLE
Javascripts 85646688

### DIFF
--- a/lib/static_website/compiler/javascripts.rb
+++ b/lib/static_website/compiler/javascripts.rb
@@ -52,7 +52,8 @@ module StaticWebsite
       end
 
       def compressed_path
-        @compressed_path ||= File.join(compile_path, "javascripts", "#{@page_name.parameterize}.min.js")
+        @compressed_path ||= File.join(compile_path, "javascripts", 
+                                       "#{@page_name.parameterize}-#{Time.now.to_i}.min.js")
       end
 
       def javascript_uploader

--- a/lib/static_website/compiler/javascripts.rb
+++ b/lib/static_website/compiler/javascripts.rb
@@ -52,8 +52,8 @@ module StaticWebsite
       end
 
       def compressed_path
-        @compressed_path ||= File.join(compile_path, "javascripts", 
-                                       "#{@page_name.parameterize}-#{Time.now.to_i}.min.js")
+        @compressed_path ||= Proc.new {File.join(compile_path, "javascripts",
+                                       "#{@page_name.parameterize}-#{Time.now.to_i}.min.js")}
       end
 
       def javascript_uploader

--- a/lib/static_website/compiler/javascripts.rb
+++ b/lib/static_website/compiler/javascripts.rb
@@ -52,8 +52,8 @@ module StaticWebsite
       end
 
       def compressed_path
-        @compressed_path ||= Proc.new {File.join(compile_path, "javascripts",
-                                       "#{@page_name.parameterize}-#{Time.now.to_i}.min.js")}
+        @compressed_path ||= File.join(compile_path, "javascripts",
+                                       "#{@page_name.parameterize}-#{Time.now.to_i}.min.js")
       end
 
       def javascript_uploader

--- a/lib/static_website/compiler/web_templates.rb
+++ b/lib/static_website/compiler/web_templates.rb
@@ -12,7 +12,7 @@ module StaticWebsite
       def compile
         web_template_models.each do |web_template_model|
           LOGGERS.each{|logger| logger.info("\n\n########################################### "\
-                                            "#{web_template_model.website.name.to_s} "\
+                                            "#{web_template_model.website.name.to_s} - "\
                                             "#{web_template_model.name.to_s} ######\n")}
           LOGGERS.each{|logger| logger.info("Starting compile_web_template for web_template: "\
                                             "#{web_template_model.name.to_s}")}

--- a/spec/lib/static_website/compiler/javascripts_spec.rb
+++ b/spec/lib/static_website/compiler/javascripts_spec.rb
@@ -107,7 +107,8 @@ describe StaticWebsite::Compiler::Javascripts do
     let(:subject) { javascripts_class.new(nil, compile_directory, "some-page") }
 
     it "matches /javascripts/some-page.min.js" do
-      expect(subject.compressed_path).to match "/javascripts/some-page.min.js"
+      allow(Time).to receive(:now).and_return "123"
+      expect(subject.compressed_path).to match "/javascripts/some-page-123.min.js"
     end
   end
 end


### PR DESCRIPTION
fixes CLW rollbacks

adds time-stamp to compressed js files per page

https://www.pivotaltracker.com/story/show/85646688