### PR TITLE
Fix page cards so edit/preview buttons show for Compass Rock corp location

### DIFF
--- a/app/assets/javascripts/templates/website/_web_page_template_front.hbs
+++ b/app/assets/javascripts/templates/website/_web_page_template_front.hbs
@@ -10,6 +10,7 @@
       {{/each}}
     </ul>
       </div>
+      <div style="height: 10px">&nbsp;</div>
     <div class="buttons">
       {{#if isWebHomeTemplate}}
         {{#link-to "webHomeTemplate" class="btn btn--small btn-left"}}Edit{{/link-to}}

--- a/app/assets/javascripts/templates/website/_web_page_template_front.hbs
+++ b/app/assets/javascripts/templates/website/_web_page_template_front.hbs
@@ -3,20 +3,21 @@
   {{ partial "website/webPageTemplateHead" }}
 
   <div class="card-body">
+      <div class="widgets-container" >
     <ul class="widgets">
       {{#each mainWidgets}}
         {{ partial "website/widget" }}
       {{/each}}
     </ul>
+      </div>
     <div class="buttons">
       {{#if isWebHomeTemplate}}
-        {{#link-to "webHomeTemplate" class="btn btn--small"}}Edit{{/link-to}}
+        {{#link-to "webHomeTemplate" class="btn btn--small btn-left"}}Edit{{/link-to}}
       {{else}}
-        {{#link-to "webPageTemplate" this class="btn btn--small"}}Edit{{/link-to}}
+        {{#link-to "webPageTemplate" this class="btn btn--small btn-left"}}Edit{{/link-to}}
       {{/if}}
-      <a {{bind-attr href="previewUrl"}} class="btn btn--small">Preview</a>
+      <a {{bind-attr href="previewUrl"}} class="btn btn--small btn-right">Preview</a>
     </div>
-
     {{ partial "website/webPageTemplateFlip" }}
   </div>
 </div>

--- a/app/assets/stylesheets/modules/_card.css.scss
+++ b/app/assets/stylesheets/modules/_card.css.scss
@@ -19,7 +19,7 @@
   @include box-sizing(border-box);
   position: relative;
   float: left;
-  height: 480px;
+  height: 320px;
   margin-bottom: $base-whitespace;
   padding-left: 1%;
   padding-right: 1%;
@@ -34,10 +34,17 @@
   @include respond-to($l-min-xlarge) {
     width: 25%;
   }
+  .widgets-container {
+    height: 185px;
+    overflow-y: scroll;
+    overflow-x: hidden;
+  }
   .widgets {
     @extend %group;
     margin-bottom: 1em;
+    height: 280px;
   }
+
   .buttons .btn {
     @include respond-to($l-min-medium, min-width) {
       width: 48%;
@@ -94,9 +101,10 @@
 .card-container {
   @include box-sizing(border-box);
   background-color: $c-background-a;
-  height: 480px;
+  height: 320px;
   padding-bottom: 50px;
   width: 100%;
+  overflow: hidden;
 }
 
 .card-head {

--- a/app/assets/stylesheets/modules/_card.css.scss
+++ b/app/assets/stylesheets/modules/_card.css.scss
@@ -36,7 +36,7 @@
   }
   .widgets-container {
     height: 185px;
-    overflow-y: scroll;
+    overflow-y: hidden;
     overflow-x: hidden;
   }
   .widgets {

--- a/app/assets/stylesheets/modules/_card.css.scss
+++ b/app/assets/stylesheets/modules/_card.css.scss
@@ -19,7 +19,7 @@
   @include box-sizing(border-box);
   position: relative;
   float: left;
-  height: 320px;
+  height: 480px;
   margin-bottom: $base-whitespace;
   padding-left: 1%;
   padding-right: 1%;
@@ -94,7 +94,7 @@
 .card-container {
   @include box-sizing(border-box);
   background-color: $c-background-a;
-  height: 320px;
+  height: 480px;
   padding-bottom: 50px;
   width: 100%;
 }


### PR DESCRIPTION
The location uses lots and lots of content stripes. This is a work around so the buttons show on pages that use a large number of content stripes, until a better solution is available.