### PR TITLE
add force_all option to garden widget updater

### DIFF
--- a/app/jobs/garden_widget_updater_job.rb
+++ b/app/jobs/garden_widget_updater_job.rb
@@ -2,7 +2,7 @@ class GardenWidgetUpdaterJob
   extend HerokuResqueAutoscaler if Rails.env.production?
   @queue = :garden_widget_updater
 
-  def self.perform
-    GardenWidgetUpdater.new.update_all
+  def self.perform(force_all=false)
+    GardenWidgetUpdater.new.update_all(force_all)
   end
 end

--- a/lib/garden_widget_updater.rb
+++ b/lib/garden_widget_updater.rb
@@ -1,7 +1,7 @@
 class GardenWidgetUpdater
   MAX_ATTEMPTS = 5
 
-  def update_all
+  def update_all(force_all=false)
     updated_garden_widgets = []
     attempts = 0
     begin
@@ -20,7 +20,7 @@ class GardenWidgetUpdater
     components_data.map do |component|
       garden_widget = GardenWidget.find_or_initialize_by(widget_id: get_widget_id(component))
       
-      if (get_url(component) != garden_widget.url) || (get_modified(component) != garden_widget.widget_modified)
+      if (force_all || get_url(component) != garden_widget.url) || (get_modified(component) != garden_widget.widget_modified)
         update(garden_widget, component)
       end
       


### PR DESCRIPTION
Enables us to force update of all Garden Widgets from the command line. Enter the following at CLI:

```
GardenWidgetUpdaterJob.perform(true)
```