### PR TITLE
Client services fix

### DIFF
--- a/spec/lib/client_services_spec.rb
+++ b/spec/lib/client_services_spec.rb
@@ -8,7 +8,7 @@ describe ClientServices do
 
   before do
     @client_services = ClientServices.new
-    @heroku_app_max_length = ClientServices::HEROKU_APP_NAME_MAX_LENGTH
+    @heroku_app_max_length = G5HerokuAppNameFormatter::Formatter::HEROKU_APP_NAME_LIMIT
   end
 
   describe "#client" do


### PR DESCRIPTION
Updates Client Services to use G5HerokuAppNameFormatter instead of it's own BS way of hacking together URLs, which is currently causing certain edge case Client URNs to explode.